### PR TITLE
Update info.xml authors with new maintainers and co-maintainers

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,7 +7,8 @@
     <description><![CDATA[Management for calendar resources and rooms]]></description>
     <version>0.1.1-alpha.1</version>
     <licence>agpl</licence>
-	<author mail="anna.larch@nextcloud.com">Anna Larch</author>
+	<author>Richard Steinmetz</author>
+	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>
 	<namespace>CalendarResourceManagement</namespace>
 	<types>
 		<prevent_group_restriction/>


### PR DESCRIPTION
Ref https://github.com/nextcloud/groupware/issues/6#issuecomment-975367771

Ideally `<author>` was named `<maintainer>`. Obviously we are all still authors. But there is now one main person to maintain the app, the rest of us are co-maintainers.