### PR TITLE
Drop support for Nextcloud 22 (EOL)

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - php-versions: '7.3'
             db: 'mysql'
-            nextcloud-versions: stable22
+            nextcloud-versions: stable23
           - php-versions: '8.0'
             db: 'mysql'
             nextcloud-versions: stable23

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
     <bugs>https://github.com/nextcloud/calendar_resource_management</bugs>
     <dependencies>
 		<php min-version="7.3" max-version="8.1" />
-		<nextcloud min-version="22" max-version="25"/>
+		<nextcloud min-version="23" max-version="25"/>
 	</dependencies>
 	<commands>
 		<command>OCA\CalendarResourceManagement\Command\CreateBuilding</command>


### PR DESCRIPTION
https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule