### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 0.4.0 - 2023-02-01
+### Added
+- Support for Nextcloud 26
+- Support for PHP 8.2
+### Removed
+- Support for Nextcloud 23 (EOL)
+- Support for PHP 7.4 (EOL)
+### Changed
+- Migrate to new backend registrations
+- Use composers authoritative classmap
+
 ## 0.3.1 - 2022-09-09
 ### Added
 - Add krankerl.toml

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
     <name>Calendar Resource Management</name>
     <summary>Management for calendar resources and rooms</summary>
     <description><![CDATA[Management for calendar resources and rooms]]></description>
-    <version>0.4.0-alpha.1</version>
+    <version>0.4.0</version>
     <licence>agpl</licence>
 	<author>Richard Steinmetz</author>
 	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>


### PR DESCRIPTION
# Changelog
## 0.4.0 - 2023-02-01
### Added
- Support for Nextcloud 26
- Support for PHP 8.2
### Removed
- Support for Nextcloud 23 (EOL)
- Support for PHP 7.4 (EOL)
### Changed
- Migrate to new backend registrations
- Use composers authoritative classmap