### PR TITLE
feat: drop support for nextcloud 26 and 27

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -12,10 +12,10 @@ jobs:
         include:
           - php-versions: '8.0'
             db: 'pgsql'
-            nextcloud-versions: stable26
+            nextcloud-versions: stable28
           - php-versions: '8.2'
             db: 'sqlite'
-            nextcloud-versions: stable27
+            nextcloud-versions: stable29
           - php-versions: '8.3'
             db: 'sqlite'
             nextcloud-versions: master

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 	<bugs>https://github.com/nextcloud/calendar_resource_management</bugs>
 	<dependencies>
 		<php min-version="8.0" max-version="8.3" />
-		<nextcloud min-version="26" max-version="30"/>
+		<nextcloud min-version="28" max-version="30"/>
 	</dependencies>
 	<commands>
 		<command>OCA\CalendarResourceManagement\Command\CreateBuilding</command>


### PR DESCRIPTION
Both versions are EOL.

Ref https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule