### PR TITLE
chore(deps): move composer-bin-plugin to deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
 		}
 	},
 	"require": {
-		"php": ">=8.0 <=8.3"
+		"php": ">=8.0 <=8.3",
+		"bamarni/composer-bin-plugin": "^1.8.2"
 	},
 	"require-dev": {
-		"bamarni/composer-bin-plugin": "^1.8.2",
 		"nextcloud/coding-standard": "^1.3.2",
 		"psalm/phar": "^5.26.1",
 		"roave/security-advisories": "dev-master"

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "49cf44417498a8e89c834c8a03fe5cb0",
-    "packages": [],
-    "packages-dev": [
+    "content-hash": "f72e6f25ec4d0c8a545abf1478aa8faf",
+    "packages": [
         {
             "name": "bamarni/composer-bin-plugin",
             "version": "1.8.2",
@@ -63,7 +62,9 @@
                 "source": "https://github.com/bamarni/composer-bin-plugin/tree/1.8.2"
             },
             "time": "2022-10-31T08:38:03+00:00"
-        },
+        }
+    ],
+    "packages-dev": [
         {
             "name": "kubawerlos/php-cs-fixer-custom-fixers",
             "version": "v3.22.0",


### PR DESCRIPTION
Breaks the release action is it does `composer i --no-dev`.