### PR TITLE
fix: validate uids of rooms, resources and vehicles

### DIFF
--- a/lib/Command/CreateResource.php
+++ b/lib/Command/CreateResource.php
@@ -11,6 +11,7 @@ namespace OCA\CalendarResourceManagement\Command;
 
 use OCA\CalendarResourceManagement\Db\ResourceMapper;
 use OCA\CalendarResourceManagement\Db\ResourceModel;
+use OCA\CalendarResourceManagement\Service\UidValidationService;
 use OCP\Calendar\Resource\IManager as IResourceManager;
 use OCP\DB\Exception;
 use Psr\Log\LoggerInterface;
@@ -38,6 +39,7 @@ class CreateResource extends Command {
 		LoggerInterface $logger,
 		ResourceMapper $resourceMapper,
 		private IResourceManager $resourceManager,
+		private UidValidationService $uidValidationService,
 	) {
 		parent::__construct();
 		$this->logger = $logger;
@@ -69,6 +71,7 @@ class CreateResource extends Command {
 		$type = (string)$input->getArgument(self::TYPE);
 		$contact = (string)$input->getOption(self::CONTACT);
 
+		$this->uidValidationService->validateUidAndThrow($uid);
 
 		$resourceModel = new ResourceModel();
 		$resourceModel->setUid($uid);

--- a/lib/Command/CreateRoom.php
+++ b/lib/Command/CreateRoom.php
@@ -11,6 +11,7 @@ namespace OCA\CalendarResourceManagement\Command;
 
 use OCA\CalendarResourceManagement\Db\RoomMapper;
 use OCA\CalendarResourceManagement\Db\RoomModel;
+use OCA\CalendarResourceManagement\Service\UidValidationService;
 use OCP\Calendar\Room\IManager as IRoomManager;
 use OCP\DB\Exception;
 use Psr\Log\LoggerInterface;
@@ -46,6 +47,7 @@ class CreateRoom extends Command {
 		LoggerInterface $logger,
 		RoomMapper $roomMapper,
 		private IRoomManager $roomManager,
+		private UidValidationService $uidValidationService,
 	) {
 		parent::__construct();
 		$this->logger = $logger;
@@ -163,6 +165,8 @@ class CreateRoom extends Command {
 		$projector = (bool)$input->getOption(self::HAS_PROJECTOR);
 		$whiteboard = (bool)$input->getOption(self::HAS_WHITEBOARD);
 		$wheelchair = (bool)$input->getOption(self::IS_WHEELCHAIR_ACCESSIBLE);
+
+		$this->uidValidationService->validateUidAndThrow($uid);
 
 		$roomModel = new RoomModel();
 		$roomModel->setStoryId($storyId);

--- a/lib/Command/CreateVehicle.php
+++ b/lib/Command/CreateVehicle.php
@@ -11,6 +11,7 @@ namespace OCA\CalendarResourceManagement\Command;
 
 use OCA\CalendarResourceManagement\Db\VehicleMapper;
 use OCA\CalendarResourceManagement\Db\VehicleModel;
+use OCA\CalendarResourceManagement\Service\UidValidationService;
 use OCP\Calendar\Resource\IManager as IResourceManager;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
@@ -42,6 +43,7 @@ class CreateVehicle extends Command {
 		LoggerInterface $logger,
 		VehicleMapper $vehicleMapper,
 		private IResourceManager $resourceManager,
+		private UidValidationService $uidValidationService,
 	) {
 		parent::__construct();
 		$this->logger = $logger;
@@ -82,6 +84,8 @@ class CreateVehicle extends Command {
 		$isElectric = (bool)$input->getOption(self::IS_ELECTRIC);
 		$range = (int)$input->getOption(self::RANGE);
 		$seating = (int)$input->getOption(self::SEATING_CAPACITY);
+
+		$this->uidValidationService->validateUidAndThrow($uid);
 
 		$vehicleModel = new VehicleModel();
 		$vehicleModel->setBuildingId($buildingId);

--- a/lib/Service/UidValidationService.php
+++ b/lib/Service/UidValidationService.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\CalendarResourceManagement\Service;
+
+use InvalidArgumentException;
+
+class UidValidationService {
+	/**
+	 * Validate whether the given uid only contains valid characters.
+	 */
+	public function validateUid(string $uid): bool {
+		// Taken from \OC\User\Manager::validateUserId
+		return !preg_match('/[^a-zA-Z0-9 _.@\-\']/', $uid);
+	}
+
+	/**
+	 * Validate whether the given uid only contains valid characters and throw otherwise.
+	 *
+	 * @throws InvalidArgumentException If the given uid is invalid.
+	 */
+	public function validateUidAndThrow(string $uid): void {
+		if (!$this->validateUid($uid)) {
+			throw new InvalidArgumentException(
+				'Only the following characters are allowed in a uid: "a-z", "A-Z", "0-9", spaces and "_.@-\'"'
+			);
+		}
+	}
+}


### PR DESCRIPTION
Users might create rooms, resources or vehicles with special characters in their uids which will break the backend later, e.g. `salle_réunion`.

Now, an exception will be thrown:
![image](https://github.com/user-attachments/assets/79f90998-dd8d-4199-bb39-51a8342c3c99)


Ref https://github.com/nextcloud/server/blob/892f815d2e82e771c36aeb67aeee46d5a0d0938c/lib/private/User/Manager.php#L748-L753