### PR TITLE
[stable0.9] chore(release): v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## 0.9.0-beta.2 - 2025-01-09
+## 0.9.0 - 2025-02-17
 ### Added
 - Support for Nextcloud 31
+- Support for PHP 8.4
+### Fixed
+- Validate uids of rooms, resources and vehicles
 
 ## 0.8.0 - 2024-07-29
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<name>Calendar Resource Management</name>
 	<summary>Management for calendar resources and rooms</summary>
 	<description><![CDATA[Management for calendar resources and rooms]]></description>
-	<version>0.9.0-beta.2</version>
+	<version>0.9.0</version>
 	<licence>agpl</licence>
 	<author>Richard Steinmetz</author>
 	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>


### PR DESCRIPTION
# Changelog

## 0.9.0 - 2025-02-17
### Added
- Support for Nextcloud 31
- Support for PHP 8.4
### Fixed
- Validate uids of rooms, resources and vehicles

Resolves https://github.com/nextcloud/calendar_resource_management/issues/173