### PR TITLE
fix: remove authoritative class map flag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
 		},
 		"sort-packages": true,
 		"optimize-autoloader": true,
-		"classmap-authoritative": true,
 		"autoloader-suffix": "CalendarResourceManagement",
 		"allow-plugins": {
 			"bamarni/composer-bin-plugin": true


### PR DESCRIPTION
### Summary
- Resolves: https://github.com/nextcloud/calendar_resource_management/issues/238