### PR TITLE
fix(command): validate parent IDs before insert in create commands

### DIFF
--- a/lib/Command/CreateRoom.php
+++ b/lib/Command/CreateRoom.php
@@ -11,7 +11,9 @@ namespace OCA\CalendarResourceManagement\Command;
 
 use OCA\CalendarResourceManagement\Db\RoomMapper;
 use OCA\CalendarResourceManagement\Db\RoomModel;
+use OCA\CalendarResourceManagement\Db\StoryMapper;
 use OCA\CalendarResourceManagement\Service\UidValidationService;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Calendar\Room\IManager as IRoomManager;
 use OCP\DB\Exception;
 use Psr\Log\LoggerInterface;
@@ -48,6 +50,7 @@ class CreateRoom extends Command {
 		RoomMapper $roomMapper,
 		private IRoomManager $roomManager,
 		private UidValidationService $uidValidationService,
+		private StoryMapper $storyMapper,
 	) {
 		parent::__construct();
 		$this->logger = $logger;
@@ -167,6 +170,13 @@ class CreateRoom extends Command {
 		$wheelchair = (bool)$input->getOption(self::IS_WHEELCHAIR_ACCESSIBLE);
 
 		$this->uidValidationService->validateUidAndThrow($uid);
+
+		try {
+			$this->storyMapper->find($storyId);
+		} catch (DoesNotExistException) {
+			$output->writeln('<error>Story with ID ' . $storyId . ' does not exist. Use `calendar-resource:resources:list` to see available stories.</error>');
+			return 1;
+		}
 
 		$roomModel = new RoomModel();
 		$roomModel->setStoryId($storyId);

--- a/lib/Command/CreateStory.php
+++ b/lib/Command/CreateStory.php
@@ -9,8 +9,10 @@ declare(strict_types=1);
 
 namespace OCA\CalendarResourceManagement\Command;
 
+use OCA\CalendarResourceManagement\Db\BuildingMapper;
 use OCA\CalendarResourceManagement\Db\StoryMapper;
 use OCA\CalendarResourceManagement\Db\StoryModel;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\DB\Exception;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
@@ -28,10 +30,14 @@ class CreateStory extends Command {
 	/** @var StoryMapper */
 	private $storyMapper;
 
-	public function __construct(LoggerInterface $logger, StoryMapper $storyMapper) {
+	/** @var BuildingMapper */
+	private $buildingMapper;
+
+	public function __construct(LoggerInterface $logger, StoryMapper $storyMapper, BuildingMapper $buildingMapper) {
 		parent::__construct();
 		$this->logger = $logger;
 		$this->storyMapper = $storyMapper;
+		$this->buildingMapper = $buildingMapper;
 	}
 
 	/**
@@ -58,6 +64,13 @@ class CreateStory extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$displayName = (string)$input->getArgument(self::DISPLAY_NAME);
 		$building = (int)$input->getArgument(self::BUILDING_ID);
+
+		try {
+			$this->buildingMapper->find($building);
+		} catch (DoesNotExistException) {
+			$output->writeln('<error>Building with ID ' . $building . ' does not exist. Use `calendar-resource:resources:list` to see available buildings.</error>');
+			return 1;
+		}
 
 		$storyModel = new StoryModel();
 		$storyModel->setDisplayName($displayName);


### PR DESCRIPTION
Check that the referenced building/story exists before attempting the DB insert, so users get a clear error and a hint to use `calendar-resource:resources:list` instead of a raw FK constraint violation.

Assisted-by: Claude:claude-sonnet-4-6



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
