### PR TITLE
chore: drop php 8.2 support from tests

### DIFF
--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -18,19 +18,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  matrix:
-    runs-on: ubuntu-latest-low
-    outputs:
-      php-version: ${{ steps.versions.outputs.php-available-list }}
-      server-max: ${{ steps.versions.outputs.branches-max-list }}
-    steps:
-      - name: Checkout app
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-
-      - name: Get version matrix
-        id: versions
-        uses: icewind1991/nextcloud-version-matrix@58becf3b4bb6dc6cef677b15e2fd8e7d48c0908f # v1.3.1
-
   changes:
     runs-on: ubuntu-latest-low
     permissions:
@@ -61,13 +48,21 @@ jobs:
   phpunit-sqlite:
     runs-on: ubuntu-latest
 
-    needs: [changes, matrix]
+    needs: changes
     if: needs.changes.outputs.src != 'false'
 
     strategy:
+      fail-fast: false
       matrix:
-        php-versions: ${{ fromJson(needs.matrix.outputs.php-version) }}
-        server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}
+        php-versions: [ '8.3', '8.4', '8.5' ]
+        server-versions: [ 'master' ]
+        include:
+          - php-versions: '8.5'
+            server-versions: 'stable34'
+          - php-versions: '8.5'
+            server-versions: 'stable33'
+          - php-versions: '8.3'
+            server-versions: 'stable32'
 
     name: SQLite PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
 

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.2', '8.3', '8.4', '8.5']
+        php-versions: ['8.3', '8.4', '8.5']
         nextcloud-versions: ['master']
         db: ['mysql', 'sqlite', 'pgsql']
         include:
@@ -71,7 +71,7 @@ jobs:
       - name: Checkout Nextcloud
         run: git clone https://github.com/nextcloud/server.git --recursive --depth 1 -b ${{ matrix.nextcloud-versions }} nextcloud
       - name: Patch version check for nightly PHP
-        if: ${{ matrix.php-versions == '8.2' }}
+        if: ${{ matrix.php-versions == '8.5' }}
         run: echo "<?php" > nextcloud/lib/versioncheck.php
       - name: Install Nextcloud
         run: php -f nextcloud/occ maintenance:install --database-host 127.0.0.1 --database-name nextcloud --database-user nextcloud --database-pass nextcloud --admin-user admin --admin-pass admin --database ${{ matrix.db }}

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@
 	<bugs>https://github.com/nextcloud/calendar_resource_management</bugs>
 	<dependencies>
 		<php min-version="8.1" max-version="8.5" />
-		<nextcloud min-version="31" max-version="34"/>
+		<nextcloud min-version="31" max-version="35"/>
 	</dependencies>
 	<commands>
 		<command>OCA\CalendarResourceManagement\Command\CreateBuilding</command>


### PR DESCRIPTION
### Summary
- Drop php 8.2 from tests until we can fully drop NC32 in september